### PR TITLE
fix token in utils.py

### DIFF
--- a/query_representation/utils.py
+++ b/query_representation/utils.py
@@ -533,7 +533,7 @@ def find_next_match(tables, wheres, index):
     tables_in_pred = find_all_tables_till_keyword(token)
     assert len(tables_in_pred) <= 2
 
-    token_list = sqlparse.sql.TokenList(wheres)
+    token_list = sqlparse.sql.TokenList(wheres).tokens
 
     while True:
         index, token = token_list.token_next(index)


### PR DESCRIPTION
When I attempt to execute sql_to_qrep.py with SQL queries containing the WHERE clause, I encounter a TypeError: object of type 'Where' has no len() error. It appears that the script is encountering difficulties handling the WHERE clause correctly, leading to this unexpected behavior.

Modify in the utils.py file can solve this problem.